### PR TITLE
xilem: Port the rest of the existing widgets and the mason example

### DIFF
--- a/xilem/examples/mason.rs
+++ b/xilem/examples/mason.rs
@@ -5,9 +5,12 @@
 #![windows_subsystem = "windows"]
 
 use xilem::{
-    view::{button, flex, textbox},
-    AnyWidgetView, EventLoop, EventLoopBuilder, WidgetView, Xilem,
+    view::{button, checkbox, flex, label, prose, textbox},
+    AnyWidgetView, Axis, Color, EventLoop, EventLoopBuilder, TextAlignment, WidgetView, Xilem,
 };
+const LOREM: &str = r"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi cursus mi sed euismod euismod. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nullam placerat efficitur tellus at semper. Morbi ac risus magna. Donec ut cursus ex. Etiam quis posuere tellus. Mauris posuere dui et turpis mollis, vitae luctus tellus consectetur. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur eu facilisis nisl.
+
+Phasellus in viverra dolor, vitae facilisis est. Maecenas malesuada massa vel ultricies feugiat. Vivamus venenatis et nibh nec pharetra. Phasellus vestibulum elit enim, nec scelerisque orci faucibus id. Vivamus consequat purus sit amet orci egestas, non iaculis massa porttitor. Vestibulum ut eros leo. In fermentum convallis magna in finibus. Donec justo leo, maximus ac laoreet id, volutpat ut elit. Mauris sed leo non neque laoreet faucibus. Aliquam orci arcu, faucibus in molestie eget, ornare non dui. Donec volutpat nulla in fringilla elementum. Aliquam vitae ante egestas ligula tempus vestibulum sit amet sed ante. ";
 
 fn app_logic(data: &mut AppData) -> impl WidgetView<AppData> {
     // here's some logic, deriving state for the view from our state
@@ -17,34 +20,74 @@ fn app_logic(data: &mut AppData) -> impl WidgetView<AppData> {
     } else {
         format!("clicked {count} times")
     };
-    let x: AnyWidgetView<AppData> =
-        Box::new(button(button_label, |data: &mut AppData| data.count += 1));
 
+    // The actual UI Code starts here
+
+    let axis = if data.active {
+        Axis::Horizontal
+    } else {
+        Axis::Vertical
+    };
+
+    let sequence = (0..count)
+        .map(|x| button(format!("+{x}"), move |data: &mut AppData| data.count += x))
+        .collect::<Vec<_>>();
     flex((
-        // This is an awful hack to work around camera notches
-        button("spacer_for_android", |_| {}),
-        button("spacer_for_android", |_| {}),
-        button(&*data.textbox_contents, |_| {}),
+        flex((
+            label("Label")
+                .color(Color::REBECCA_PURPLE)
+                .alignment(TextAlignment::Start),
+            // label("Disabled label").disabled(), TODO masonry doesn't allow setting disabled manually anymore?
+        ))
+        .direction(Axis::Horizontal),
         textbox(
             data.textbox_contents.clone(),
             |data: &mut AppData, new_value| {
                 data.textbox_contents = new_value;
             },
         ),
-        x,
-        button("test", |_| {}),
+        prose(LOREM).alignment(TextAlignment::Middle),
+        button(button_label, |data: &mut AppData| data.count += 1),
+        checkbox("Check me", data.active, |data: &mut AppData, checked| {
+            data.active = checked;
+        }),
+        toggleable(data),
+        button("Decrement", |data: &mut AppData| data.count -= 1),
+        button("Reset", |data: &mut AppData| data.count = 0),
+        flex(sequence).direction(axis),
     ))
+}
+
+fn toggleable(data: &mut AppData) -> impl WidgetView<AppData> {
+    let inner_view: AnyWidgetView<_, _> = if data.active {
+        Box::new(
+            flex((
+                button("Deactivate", |data: &mut AppData| {
+                    data.active = false;
+                }),
+                button("Unlimited Power", |data: &mut AppData| {
+                    data.count = -1_000_000;
+                }),
+            ))
+            .direction(Axis::Horizontal),
+        )
+    } else {
+        Box::new(button("Activate", |data: &mut AppData| data.active = true))
+    };
+    inner_view
 }
 
 struct AppData {
     textbox_contents: String,
     count: i32,
+    active: bool,
 }
 
 fn run(event_loop: EventLoopBuilder) {
     let data = AppData {
         count: 0,
         textbox_contents: "Not quite a placeholder".into(),
+        active: false,
     };
 
     let app = Xilem::new(data, app_logic);
@@ -84,81 +127,3 @@ fn android_main(app: AndroidApp) {
 fn main() {
     unreachable!()
 }
-
-// use xilem::view::{button, checkbox, flex, label, prose, textbox};
-// use xilem::{Axis, Color, DynWidgetView, MasonryView, TextAlignment, Xilem};
-
-// const LOREM: &str = r"Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi cursus mi sed euismod euismod. Orci varius natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Nullam placerat efficitur tellus at semper. Morbi ac risus magna. Donec ut cursus ex. Etiam quis posuere tellus. Mauris posuere dui et turpis mollis, vitae luctus tellus consectetur. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur eu facilisis nisl.
-
-// Phasellus in viverra dolor, vitae facilisis est. Maecenas malesuada massa vel ultricies feugiat. Vivamus venenatis et nibh nec pharetra. Phasellus vestibulum elit enim, nec scelerisque orci faucibus id. Vivamus consequat purus sit amet orci egestas, non iaculis massa porttitor. Vestibulum ut eros leo. In fermentum convallis magna in finibus. Donec justo leo, maximus ac laoreet id, volutpat ut elit. Mauris sed leo non neque laoreet faucibus. Aliquam orci arcu, faucibus in molestie eget, ornare non dui. Donec volutpat nulla in fringilla elementum. Aliquam vitae ante egestas ligula tempus vestibulum sit amet sed ante. ";
-
-// fn app_logic(data: &mut AppData) -> impl MasonryView<AppData> {
-//     // here's some logic, deriving state for the view from our state
-//     let count = data.count;
-//     let button_label = if count == 1 {
-//         "clicked 1 time".to_string()
-//     } else {
-//         format!("clicked {count} times")
-//     };
-
-//     // The actual UI Code starts here
-
-//     let axis = if data.active {
-//         Axis::Horizontal
-//     } else {
-//         Axis::Vertical
-//     };
-
-//     let sequence = (0..count)
-//         .map(|x| button(format!("+{x}"), move |data: &mut AppData| data.count += x))
-//         .collect::<Vec<_>>();
-//     flex((
-//         flex((
-//             label("Label")
-//                 .color(Color::REBECCA_PURPLE)
-//                 .alignment(TextAlignment::Start),
-//             label("Disabled label").disabled(),
-//         ))
-//         .direction(Axis::Horizontal),
-//         textbox(
-//             data.textbox_contents.clone(),
-//             |data: &mut AppData, new_value| {
-//                 data.textbox_contents = new_value;
-//             },
-//         ),
-//         prose(LOREM).alignment(TextAlignment::Middle),
-//         button(button_label, |data: &mut AppData| data.count += 1),
-//         checkbox("Check me", data.active, |data: &mut AppData, checked| {
-//             data.active = checked;
-//         }),
-//         toggleable(data),
-//         button("Decrement", |data: &mut AppData| data.count -= 1),
-//         button("Reset", |data: &mut AppData| data.count = 0),
-//         flex(sequence).direction(axis),
-//     ))
-// }
-
-// fn toggleable(data: &mut AppData) -> impl MasonryView<AppData> {
-//     let inner_view: DynWidgetView<_, _> = if data.active {
-//         Box::new(
-//             flex((
-//                 button("Deactivate", |data: &mut AppData| {
-//                     data.active = false;
-//                 }),
-//                 button("Unlimited Power", |data: &mut AppData| {
-//                     data.count = -1_000_000;
-//                 }),
-//             ))
-//             .direction(Axis::Horizontal),
-//         )
-//     } else {
-//         Box::new(button("Activate", |data: &mut AppData| data.active = true))
-//     };
-//     inner_view
-// }
-
-// struct AppData {
-//     textbox_contents: String,
-//     count: i32,
-//     active: bool,
-// }

--- a/xilem/src/view/label.rs
+++ b/xilem/src/view/label.rs
@@ -1,9 +1,12 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry::{widget::WidgetMut, ArcStr, WidgetPod};
+use masonry::{
+    widget::{self, WidgetMut},
+    ArcStr, WidgetPod,
+};
 
-use crate::{Color, MasonryView, MessageResult, TextAlignment, ViewCtx, ViewId};
+use crate::{Color, MessageResult, Pod, TextAlignment, View, ViewCtx, ViewId};
 
 pub fn label(label: impl Into<ArcStr>) -> Label {
     Label {
@@ -39,25 +42,25 @@ impl Label {
     }
 }
 
-impl<State, Action> MasonryView<State, Action> for Label {
-    type Element = masonry::widget::Label;
+impl<State, Action> View<State, Action, ViewCtx> for Label {
+    type Element = Pod<widget::Label>;
     type ViewState = ();
 
-    fn build(&self, _cx: &mut ViewCtx) -> (WidgetPod<Self::Element>, Self::ViewState) {
+    fn build(&self, _cx: &mut ViewCtx) -> (Self::Element, Self::ViewState) {
         let widget_pod = WidgetPod::new(
-            masonry::widget::Label::new(self.label.clone())
+            widget::Label::new(self.label.clone())
                 .with_text_brush(self.text_color)
                 .with_text_alignment(self.alignment),
         );
-        (widget_pod, ())
+        (widget_pod.into(), ())
     }
 
     fn rebuild(
         &self,
-        _view_state: &mut Self::ViewState,
-        cx: &mut ViewCtx,
         prev: &Self,
-        mut element: WidgetMut<Self::Element>,
+        (): &mut Self::ViewState,
+        cx: &mut ViewCtx,
+        mut element: WidgetMut<'_, widget::Label>,
     ) {
         if prev.label != self.label {
             element.set_text(self.label.clone());
@@ -77,11 +80,14 @@ impl<State, Action> MasonryView<State, Action> for Label {
         }
     }
 
+    fn teardown(&self, (): &mut Self::ViewState, _: &mut ViewCtx, _: WidgetMut<'_, widget::Label>) {
+    }
+
     fn message(
         &self,
-        _view_state: &mut Self::ViewState,
+        (): &mut Self::ViewState,
         _id_path: &[ViewId],
-        message: Box<dyn std::any::Any>,
+        message: xilem_core::DynMessage,
         _app_state: &mut State,
     ) -> crate::MessageResult<Action> {
         tracing::error!("Message arrived in Label::message, but Label doesn't consume any messages, this is a bug");

--- a/xilem/src/view/mod.rs
+++ b/xilem/src/view/mod.rs
@@ -4,20 +4,20 @@
 mod button;
 pub use button::*;
 
-// mod checkbox;
-// pub use checkbox::*;
+mod checkbox;
+pub use checkbox::*;
 
 mod flex;
 pub use flex::*;
 
-// mod label;
-// pub use label::*;
+mod label;
+pub use label::*;
 
 // mod memoize;
 // pub use memoize::*;
 
-// mod prose;
-// pub use prose::*;
+mod prose;
+pub use prose::*;
 
 mod textbox;
 pub use textbox::*;


### PR DESCRIPTION
This should port the rest of the widgets and the old mason example (just memoize is missing, I'm looking into whether that fits into core).

What this revealed though, is a bug within the `AnyView` I haven't looked into that in detail yet, maybe you're faster in finding the issue, it's about casting between changing element types that seem to fail. Try clicking the checkbox...