### PR TITLE
xilem_core: return element in `View::rebuild`

### DIFF
--- a/xilem/src/view/button.rs
+++ b/xilem/src/view/button.rs
@@ -2,10 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{core::View, Pod};
-use masonry::{
-    widget::{self, WidgetMut},
-    ArcStr,
-};
+use masonry::{widget, ArcStr};
+use xilem_core::Mut;
 
 use crate::{MessageResult, ViewCtx, ViewId};
 
@@ -35,24 +33,25 @@ where
         ctx.with_leaf_action_widget(|_| Pod::new(widget::Button::new(self.label.clone())))
     }
 
-    fn rebuild(
+    fn rebuild<'el>(
         &self,
         prev: &Self,
         _: &mut Self::ViewState,
         ctx: &mut ViewCtx,
-        mut element: WidgetMut<widget::Button>,
-    ) {
+        mut element: Mut<'el, Pod<widget::Button>>,
+    ) -> Mut<'el, Pod<widget::Button>> {
         if prev.label != self.label {
             element.set_text(self.label.clone());
             ctx.mark_changed();
         }
+        element
     }
 
     fn teardown(
         &self,
         _: &mut Self::ViewState,
         ctx: &mut ViewCtx,
-        element: <Self::Element as xilem_core::ViewElement>::Mut<'_>,
+        element: Mut<'_, Pod<widget::Button>>,
     ) {
         ctx.teardown_leaf(element);
     }

--- a/xilem/src/view/button.rs
+++ b/xilem/src/view/button.rs
@@ -38,8 +38,8 @@ where
         prev: &Self,
         _: &mut Self::ViewState,
         ctx: &mut ViewCtx,
-        mut element: Mut<'el, Pod<widget::Button>>,
-    ) -> Mut<'el, Pod<widget::Button>> {
+        mut element: Mut<'el, Self::Element>,
+    ) -> Mut<'el, Self::Element> {
         if prev.label != self.label {
             element.set_text(self.label.clone());
             ctx.mark_changed();
@@ -51,7 +51,7 @@ where
         &self,
         _: &mut Self::ViewState,
         ctx: &mut ViewCtx,
-        element: Mut<'_, Pod<widget::Button>>,
+        element: Mut<'_, Self::Element>,
     ) {
         ctx.teardown_leaf(element);
     }

--- a/xilem/src/view/checkbox.rs
+++ b/xilem/src/view/checkbox.rs
@@ -1,10 +1,8 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry::{
-    widget::{self, WidgetMut},
-    ArcStr,
-};
+use masonry::{widget, ArcStr};
+use xilem_core::Mut;
 
 use crate::{MessageResult, Pod, View, ViewCtx, ViewId};
 
@@ -45,13 +43,13 @@ where
         })
     }
 
-    fn rebuild(
+    fn rebuild<'el>(
         &self,
         prev: &Self,
         (): &mut Self::ViewState,
         ctx: &mut ViewCtx,
-        mut element: WidgetMut<'_, widget::Checkbox>,
-    ) {
+        mut element: Mut<'el, Pod<widget::Checkbox>>,
+    ) -> Mut<'el, Pod<widget::Checkbox>> {
         if prev.label != self.label {
             element.set_text(self.label.clone());
             ctx.mark_changed();
@@ -60,13 +58,14 @@ where
             element.set_checked(self.checked);
             ctx.mark_changed();
         }
+        element
     }
 
     fn teardown(
         &self,
         (): &mut Self::ViewState,
         ctx: &mut ViewCtx,
-        element: WidgetMut<'_, widget::Checkbox>,
+        element: Mut<'_, Pod<widget::Checkbox>>,
     ) {
         ctx.teardown_leaf(element);
     }

--- a/xilem/src/view/checkbox.rs
+++ b/xilem/src/view/checkbox.rs
@@ -48,8 +48,8 @@ where
         prev: &Self,
         (): &mut Self::ViewState,
         ctx: &mut ViewCtx,
-        mut element: Mut<'el, Pod<widget::Checkbox>>,
-    ) -> Mut<'el, Pod<widget::Checkbox>> {
+        mut element: Mut<'el, Self::Element>,
+    ) -> Mut<'el, Self::Element> {
         if prev.label != self.label {
             element.set_text(self.label.clone());
             ctx.mark_changed();
@@ -65,7 +65,7 @@ where
         &self,
         (): &mut Self::ViewState,
         ctx: &mut ViewCtx,
-        element: Mut<'_, Pod<widget::Checkbox>>,
+        element: Mut<'_, Self::Element>,
     ) {
         ctx.teardown_leaf(element);
     }

--- a/xilem/src/view/flex.rs
+++ b/xilem/src/view/flex.rs
@@ -80,8 +80,8 @@ where
         prev: &Self,
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
-        mut element: Mut<'el, Pod<widget::Flex>>,
-    ) -> Mut<'el, Pod<widget::Flex>> {
+        mut element: Mut<'el, Self::Element>,
+    ) -> Mut<'el, Self::Element> {
         if prev.axis != self.axis {
             element.set_direction(self.axis);
             ctx.mark_changed();
@@ -115,7 +115,7 @@ where
         &self,
         view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
-        mut element: Mut<'_, Pod<widget::Flex>>,
+        mut element: Mut<'_, Self::Element>,
     ) {
         let mut splice = FlexSplice {
             // Skip the initial spacer which is always present

--- a/xilem/src/view/label.rs
+++ b/xilem/src/view/label.rs
@@ -58,8 +58,8 @@ impl<State, Action> View<State, Action, ViewCtx> for Label {
         prev: &Self,
         (): &mut Self::ViewState,
         ctx: &mut ViewCtx,
-        mut element: Mut<'el, Pod<widget::Label>>,
-    ) -> Mut<'el, Pod<widget::Label>> {
+        mut element: Mut<'el, Self::Element>,
+    ) -> Mut<'el, Self::Element> {
         if prev.label != self.label {
             element.set_text(self.label.clone());
             ctx.mark_changed();
@@ -79,7 +79,7 @@ impl<State, Action> View<State, Action, ViewCtx> for Label {
         element
     }
 
-    fn teardown(&self, (): &mut Self::ViewState, _: &mut ViewCtx, _: Mut<'_, Pod<widget::Label>>) {}
+    fn teardown(&self, (): &mut Self::ViewState, _: &mut ViewCtx, _: Mut<'_, Self::Element>) {}
 
     fn message(
         &self,

--- a/xilem/src/view/label.rs
+++ b/xilem/src/view/label.rs
@@ -1,10 +1,8 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry::{
-    widget::{self, WidgetMut},
-    ArcStr,
-};
+use masonry::{widget, ArcStr};
+use xilem_core::Mut;
 
 use crate::{Color, MessageResult, Pod, TextAlignment, View, ViewCtx, ViewId};
 
@@ -55,13 +53,13 @@ impl<State, Action> View<State, Action, ViewCtx> for Label {
         (widget_pod, ())
     }
 
-    fn rebuild(
+    fn rebuild<'el>(
         &self,
         prev: &Self,
         (): &mut Self::ViewState,
         ctx: &mut ViewCtx,
-        mut element: WidgetMut<'_, widget::Label>,
-    ) {
+        mut element: Mut<'el, Pod<widget::Label>>,
+    ) -> Mut<'el, Pod<widget::Label>> {
         if prev.label != self.label {
             element.set_text(self.label.clone());
             ctx.mark_changed();
@@ -78,10 +76,10 @@ impl<State, Action> View<State, Action, ViewCtx> for Label {
             element.set_alignment(self.alignment);
             ctx.mark_changed();
         }
+        element
     }
 
-    fn teardown(&self, (): &mut Self::ViewState, _: &mut ViewCtx, _: WidgetMut<'_, widget::Label>) {
-    }
+    fn teardown(&self, (): &mut Self::ViewState, _: &mut ViewCtx, _: Mut<'_, Pod<widget::Label>>) {}
 
     fn message(
         &self,

--- a/xilem/src/view/prose.rs
+++ b/xilem/src/view/prose.rs
@@ -1,11 +1,8 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry::{
-    text2::TextBrush,
-    widget::{self, WidgetMut},
-    ArcStr,
-};
+use masonry::{text2::TextBrush, widget, ArcStr};
+use xilem_core::Mut;
 
 use crate::{Color, MessageResult, Pod, TextAlignment, View, ViewCtx, ViewId};
 
@@ -57,13 +54,13 @@ impl<State, Action> View<State, Action, ViewCtx> for Prose {
         (widget_pod, ())
     }
 
-    fn rebuild(
+    fn rebuild<'el>(
         &self,
         prev: &Self,
         (): &mut Self::ViewState,
         ctx: &mut ViewCtx,
-        mut element: WidgetMut<'_, widget::Prose>,
-    ) {
+        mut element: Mut<'el, Pod<widget::Prose>>,
+    ) -> Mut<'el, Pod<widget::Prose>> {
         if prev.label != self.label {
             element.set_text(self.label.clone());
             ctx.mark_changed();
@@ -76,10 +73,10 @@ impl<State, Action> View<State, Action, ViewCtx> for Prose {
             element.set_alignment(self.alignment);
             ctx.mark_changed();
         }
+        element
     }
 
-    fn teardown(&self, (): &mut Self::ViewState, _: &mut ViewCtx, _: WidgetMut<'_, widget::Prose>) {
-    }
+    fn teardown(&self, (): &mut Self::ViewState, _: &mut ViewCtx, _: Mut<'_, Pod<widget::Prose>>) {}
 
     fn message(
         &self,

--- a/xilem/src/view/prose.rs
+++ b/xilem/src/view/prose.rs
@@ -59,8 +59,8 @@ impl<State, Action> View<State, Action, ViewCtx> for Prose {
         prev: &Self,
         (): &mut Self::ViewState,
         ctx: &mut ViewCtx,
-        mut element: Mut<'el, Pod<widget::Prose>>,
-    ) -> Mut<'el, Pod<widget::Prose>> {
+        mut element: Mut<'el, Self::Element>,
+    ) -> Mut<'el, Self::Element> {
         if prev.label != self.label {
             element.set_text(self.label.clone());
             ctx.mark_changed();
@@ -76,7 +76,7 @@ impl<State, Action> View<State, Action, ViewCtx> for Prose {
         element
     }
 
-    fn teardown(&self, (): &mut Self::ViewState, _: &mut ViewCtx, _: Mut<'_, Pod<widget::Prose>>) {}
+    fn teardown(&self, (): &mut Self::ViewState, _: &mut ViewCtx, _: Mut<'_, Self::Element>) {}
 
     fn message(
         &self,

--- a/xilem/src/view/textbox.rs
+++ b/xilem/src/view/textbox.rs
@@ -1,11 +1,8 @@
 // Copyright 2024 the Xilem Authors
 // SPDX-License-Identifier: Apache-2.0
 
-use masonry::{
-    text2::TextBrush,
-    widget::{self, WidgetMut},
-};
-use xilem_core::View;
+use masonry::{text2::TextBrush, widget};
+use xilem_core::{Mut, View};
 
 use crate::{Color, MessageResult, Pod, TextAlignment, ViewCtx, ViewId};
 
@@ -80,13 +77,13 @@ impl<State: 'static, Action: 'static> View<State, Action, ViewCtx> for Textbox<S
         })
     }
 
-    fn rebuild(
+    fn rebuild<'el>(
         &self,
         prev: &Self,
         _: &mut Self::ViewState,
         ctx: &mut ViewCtx,
-        mut element: WidgetMut<widget::Textbox>,
-    ) {
+        mut element: Mut<'el, Pod<widget::Textbox>>,
+    ) -> Mut<'el, Pod<widget::Textbox>> {
         // Unlike the other properties, we don't compare to the previous value;
         // instead, we compare directly to the element's text. This is to handle
         // cases like "Previous data says contents is 'fooba', user presses 'r',
@@ -107,13 +104,14 @@ impl<State: 'static, Action: 'static> View<State, Action, ViewCtx> for Textbox<S
             element.set_alignment(self.alignment);
             ctx.mark_changed();
         }
+        element
     }
 
     fn teardown(
         &self,
         _: &mut Self::ViewState,
         ctx: &mut ViewCtx,
-        element: <Self::Element as xilem_core::ViewElement>::Mut<'_>,
+        element: Mut<'_, Pod<widget::Textbox>>,
     ) {
         ctx.teardown_leaf(element);
     }

--- a/xilem/src/view/textbox.rs
+++ b/xilem/src/view/textbox.rs
@@ -82,8 +82,8 @@ impl<State: 'static, Action: 'static> View<State, Action, ViewCtx> for Textbox<S
         prev: &Self,
         _: &mut Self::ViewState,
         ctx: &mut ViewCtx,
-        mut element: Mut<'el, Pod<widget::Textbox>>,
-    ) -> Mut<'el, Pod<widget::Textbox>> {
+        mut element: Mut<'el, Self::Element>,
+    ) -> Mut<'el, Self::Element> {
         // Unlike the other properties, we don't compare to the previous value;
         // instead, we compare directly to the element's text. This is to handle
         // cases like "Previous data says contents is 'fooba', user presses 'r',
@@ -111,7 +111,7 @@ impl<State: 'static, Action: 'static> View<State, Action, ViewCtx> for Textbox<S
         &self,
         _: &mut Self::ViewState,
         ctx: &mut ViewCtx,
-        element: Mut<'_, Pod<widget::Textbox>>,
+        element: Mut<'_, Self::Element>,
     ) {
         ctx.teardown_leaf(element);
     }

--- a/xilem_core/examples/filesystem.rs
+++ b/xilem_core/examples/filesystem.rs
@@ -162,8 +162,8 @@ impl<State, Action> View<State, Action, ViewCtx> for File {
         prev: &Self,
         _view_state: &mut Self::ViewState,
         ctx: &mut ViewCtx,
-        element: Mut<'el, FsPath>,
-    ) -> Mut<'el, FsPath> {
+        element: Mut<'el, Self::Element>,
+    ) -> Mut<'el, Self::Element> {
         if prev.name != self.name {
             let new_path = ctx.current_folder_path.join(&*self.name);
             let _ = std::fs::rename(&element, &new_path);

--- a/xilem_core/examples/user_interface.rs
+++ b/xilem_core/examples/user_interface.rs
@@ -62,8 +62,8 @@ impl<State, Action> View<State, Action, ViewCtx> for Button {
         _prev: &Self,
         _view_state: &mut Self::ViewState,
         _ctx: &mut ViewCtx,
-        element: Mut<'el, WidgetPod<ButtonWidget>>,
-    ) -> Mut<'el, WidgetPod<ButtonWidget>> {
+        element: Mut<'el, Self::Element>,
+    ) -> Mut<'el, Self::Element> {
         // Nothing to do
         element
     }
@@ -72,7 +72,7 @@ impl<State, Action> View<State, Action, ViewCtx> for Button {
         &self,
         _view_state: &mut Self::ViewState,
         _ctx: &mut ViewCtx,
-        _element: Mut<'_, WidgetPod<ButtonWidget>>,
+        _element: Mut<'_, Self::Element>,
     ) {
         // Nothing to do
     }

--- a/xilem_core/examples/user_interface.rs
+++ b/xilem_core/examples/user_interface.rs
@@ -6,7 +6,7 @@
 use core::any::Any;
 
 use xilem_core::{
-    DynMessage, MessageResult, SuperElement, View, ViewElement, ViewId, ViewPathTracker,
+    DynMessage, MessageResult, Mut, SuperElement, View, ViewElement, ViewId, ViewPathTracker,
 };
 
 pub fn app_logic(_: &mut u32) -> impl WidgetView<u32> {
@@ -57,21 +57,22 @@ impl<State, Action> View<State, Action, ViewCtx> for Button {
         )
     }
 
-    fn rebuild(
+    fn rebuild<'el>(
         &self,
         _prev: &Self,
         _view_state: &mut Self::ViewState,
         _ctx: &mut ViewCtx,
-        _element: <Self::Element as ViewElement>::Mut<'_>,
-    ) {
+        element: Mut<'el, WidgetPod<ButtonWidget>>,
+    ) -> Mut<'el, WidgetPod<ButtonWidget>> {
         // Nothing to do
+        element
     }
 
     fn teardown(
         &self,
         _view_state: &mut Self::ViewState,
         _ctx: &mut ViewCtx,
-        _element: <Self::Element as ViewElement>::Mut<'_>,
+        _element: Mut<'_, WidgetPod<ButtonWidget>>,
     ) {
         // Nothing to do
     }

--- a/xilem_core/src/any_view.rs
+++ b/xilem_core/src/any_view.rs
@@ -83,8 +83,8 @@ where
         dyn_state: &mut AnyViewState,
         ctx: &mut Context,
         prev: &dyn AnyView<State, Action, Context, DynamicElement>,
-        mut element: Mut<'el, DynamicElement>,
-    ) -> Mut<'el, DynamicElement> {
+        mut element: DynamicElement::Mut<'el>,
+    ) -> DynamicElement::Mut<'el> {
         if let Some(prev) = prev.as_any().downcast_ref() {
             // If we were previously of this type, then do a normal rebuild
             DynamicElement::with_downcast(element, |element| {
@@ -115,8 +115,8 @@ where
         &self,
         dyn_state: &mut AnyViewState,
         ctx: &mut Context,
-        element: Mut<'el, DynamicElement>,
-    ) -> Mut<'el, DynamicElement> {
+        element: DynamicElement::Mut<'el>,
+    ) -> DynamicElement::Mut<'el> {
         let state = dyn_state
             .inner_state
             .downcast_mut()
@@ -180,8 +180,8 @@ where
         prev: &Self,
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
-        element: Mut<'el, Element>,
-    ) -> Mut<'el, Element> {
+        element: Mut<'el, Self::Element>,
+    ) -> Mut<'el, Self::Element> {
         self.dyn_rebuild(view_state, ctx, prev, element)
     }
 
@@ -189,7 +189,7 @@ where
         &self,
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
-        element: Mut<'_, Element>,
+        element: Mut<'_, Self::Element>,
     ) {
         self.dyn_teardown(view_state, ctx, element);
     }
@@ -226,8 +226,8 @@ where
         prev: &Self,
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
-        element: Mut<'el, Element>,
-    ) -> Mut<'el, Element> {
+        element: Mut<'el, Self::Element>,
+    ) -> Mut<'el, Self::Element> {
         self.dyn_rebuild(view_state, ctx, prev, element)
     }
 
@@ -235,7 +235,7 @@ where
         &self,
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
-        element: Mut<'_, Element>,
+        element: Mut<'_, Self::Element>,
     ) {
         self.dyn_teardown(view_state, ctx, element);
     }
@@ -271,8 +271,8 @@ where
         prev: &Self,
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
-        element: Mut<'el, Element>,
-    ) -> Mut<'el, Element> {
+        element: Mut<'el, Self::Element>,
+    ) -> Mut<'el, Self::Element> {
         self.dyn_rebuild(view_state, ctx, prev, element)
     }
 
@@ -280,7 +280,7 @@ where
         &self,
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
-        element: Mut<'_, Element>,
+        element: Mut<'_, Self::Element>,
     ) {
         self.dyn_teardown(view_state, ctx, element);
     }
@@ -316,8 +316,8 @@ where
         prev: &Self,
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
-        element: Mut<'el, Element>,
-    ) -> Mut<'el, Element> {
+        element: Mut<'el, Self::Element>,
+    ) -> Mut<'el, Self::Element> {
         self.dyn_rebuild(view_state, ctx, prev, element)
     }
 
@@ -325,7 +325,7 @@ where
         &self,
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
-        element: Mut<'_, Element>,
+        element: Mut<'_, Self::Element>,
     ) {
         self.dyn_teardown(view_state, ctx, element);
     }

--- a/xilem_core/src/any_view.rs
+++ b/xilem_core/src/any_view.rs
@@ -7,7 +7,7 @@ use core::any::Any;
 
 use alloc::boxed::Box;
 
-use crate::{AnyElement, DynMessage, MessageResult, View, ViewId, ViewPathTracker};
+use crate::{AnyElement, DynMessage, MessageResult, Mut, View, ViewId, ViewPathTracker};
 
 /// A view which can have any view type where the [`View::Element`] is compatible with
 /// `Element`.
@@ -28,13 +28,13 @@ pub trait AnyView<State, Action, Context, Element: crate::ViewElement> {
 
     fn dyn_build(&self, ctx: &mut Context) -> (Element, AnyViewState);
 
-    fn dyn_rebuild(
+    fn dyn_rebuild<'el>(
         &self,
         dyn_state: &mut AnyViewState,
         ctx: &mut Context,
         prev: &dyn AnyView<State, Action, Context, Element>,
-        element: Element::Mut<'_>,
-    );
+        element: Element::Mut<'el>,
+    ) -> Element::Mut<'el>;
 
     /// Returns `Element::Mut<'el>` so that the element can be
     /// returned and replaced in `dyn_rebuild`, if needed
@@ -78,13 +78,13 @@ where
         )
     }
 
-    fn dyn_rebuild(
+    fn dyn_rebuild<'el>(
         &self,
         dyn_state: &mut AnyViewState,
         ctx: &mut Context,
         prev: &dyn AnyView<State, Action, Context, DynamicElement>,
-        mut element: <DynamicElement as crate::ViewElement>::Mut<'_>,
-    ) {
+        mut element: Mut<'el, DynamicElement>,
+    ) -> Mut<'el, DynamicElement> {
         if let Some(prev) = prev.as_any().downcast_ref() {
             // If we were previously of this type, then do a normal rebuild
             DynamicElement::with_downcast(element, |element| {
@@ -96,7 +96,7 @@ where
                 ctx.with_id(ViewId::new(dyn_state.generation), move |ctx| {
                     self.rebuild(prev, state, ctx, element);
                 });
-            });
+            })
         } else {
             // Otherwise, teardown the old element, then replace the value
             element = prev.dyn_teardown(dyn_state, ctx, element);
@@ -108,15 +108,15 @@ where
             let (new_element, view_state) =
                 ctx.with_id(ViewId::new(dyn_state.generation), |ctx| self.build(ctx));
             dyn_state.inner_state = Box::new(view_state);
-            DynamicElement::replace_inner(element, new_element);
+            DynamicElement::replace_inner(element, new_element)
         }
     }
     fn dyn_teardown<'el>(
         &self,
         dyn_state: &mut AnyViewState,
         ctx: &mut Context,
-        element: <DynamicElement as crate::ViewElement>::Mut<'el>,
-    ) -> <DynamicElement as crate::ViewElement>::Mut<'el> {
+        element: Mut<'el, DynamicElement>,
+    ) -> Mut<'el, DynamicElement> {
         let state = dyn_state
             .inner_state
             .downcast_mut()
@@ -175,21 +175,21 @@ where
         self.dyn_build(ctx)
     }
 
-    fn rebuild(
+    fn rebuild<'el>(
         &self,
         prev: &Self,
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
-        element: <Self::Element as crate::ViewElement>::Mut<'_>,
-    ) {
-        self.dyn_rebuild(view_state, ctx, prev, element);
+        element: Mut<'el, Element>,
+    ) -> Mut<'el, Element> {
+        self.dyn_rebuild(view_state, ctx, prev, element)
     }
 
     fn teardown(
         &self,
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
-        element: <Self::Element as crate::ViewElement>::Mut<'_>,
+        element: Mut<'_, Element>,
     ) {
         self.dyn_teardown(view_state, ctx, element);
     }
@@ -221,21 +221,21 @@ where
         self.dyn_build(ctx)
     }
 
-    fn rebuild(
+    fn rebuild<'el>(
         &self,
         prev: &Self,
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
-        element: <Self::Element as crate::ViewElement>::Mut<'_>,
-    ) {
-        self.dyn_rebuild(view_state, ctx, prev, element);
+        element: Mut<'el, Element>,
+    ) -> Mut<'el, Element> {
+        self.dyn_rebuild(view_state, ctx, prev, element)
     }
 
     fn teardown(
         &self,
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
-        element: <Self::Element as crate::ViewElement>::Mut<'_>,
+        element: Mut<'_, Element>,
     ) {
         self.dyn_teardown(view_state, ctx, element);
     }
@@ -266,21 +266,21 @@ where
         self.dyn_build(ctx)
     }
 
-    fn rebuild(
+    fn rebuild<'el>(
         &self,
         prev: &Self,
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
-        element: <Self::Element as crate::ViewElement>::Mut<'_>,
-    ) {
-        self.dyn_rebuild(view_state, ctx, prev, element);
+        element: Mut<'el, Element>,
+    ) -> Mut<'el, Element> {
+        self.dyn_rebuild(view_state, ctx, prev, element)
     }
 
     fn teardown(
         &self,
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
-        element: <Self::Element as crate::ViewElement>::Mut<'_>,
+        element: Mut<'_, Element>,
     ) {
         self.dyn_teardown(view_state, ctx, element);
     }
@@ -311,21 +311,21 @@ where
         self.dyn_build(ctx)
     }
 
-    fn rebuild(
+    fn rebuild<'el>(
         &self,
         prev: &Self,
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
-        element: <Self::Element as crate::ViewElement>::Mut<'_>,
-    ) {
-        self.dyn_rebuild(view_state, ctx, prev, element);
+        element: Mut<'el, Element>,
+    ) -> Mut<'el, Element> {
+        self.dyn_rebuild(view_state, ctx, prev, element)
     }
 
     fn teardown(
         &self,
         view_state: &mut Self::ViewState,
         ctx: &mut Context,
-        element: <Self::Element as crate::ViewElement>::Mut<'_>,
+        element: Mut<'_, Element>,
     ) {
         self.dyn_teardown(view_state, ctx, element);
     }

--- a/xilem_core/src/lib.rs
+++ b/xilem_core/src/lib.rs
@@ -45,6 +45,6 @@ pub use any_view::AnyView;
 mod sequence;
 pub use sequence::{AppendVec, ElementSplice, ViewSequence};
 
-/// This alias is mostly syntax sugar to avoid the elaborate expansion of
+/// This alias is syntax sugar to avoid the elaborate expansion of
 /// `<Self::Element as ViewElement>::Mut<'el>` in the View trait when implementing it (e.g. via rust-analyzer)
 pub type Mut<'el, E> = <E as ViewElement>::Mut<'el>;

--- a/xilem_core/src/lib.rs
+++ b/xilem_core/src/lib.rs
@@ -44,3 +44,7 @@ pub use any_view::AnyView;
 
 mod sequence;
 pub use sequence::{AppendVec, ElementSplice, ViewSequence};
+
+/// This alias is mostly syntax sugar to avoid the elaborate expansion of
+/// `<Self::Element as ViewElement>::Mut<'el>` in the View trait when implementing it (e.g. via rust-analyzer)
+pub type Mut<'el, E> = <E as ViewElement>::Mut<'el>;

--- a/xilem_core/src/view.rs
+++ b/xilem_core/src/view.rs
@@ -50,6 +50,10 @@ pub trait View<State, Action, Context: ViewPathTracker>: 'static {
     fn build(&self, ctx: &mut Context) -> (Self::Element, Self::ViewState);
 
     /// Update `element` based on the difference between `self` and `prev`.
+    ///
+    /// This returns `element`, to allow parent views to modify the element after this `rebuild` has
+    /// completed. This returning is needed as some reference types do not allow reborrowing,
+    /// without unweildly boilerplate.
     fn rebuild<'el>(
         &self,
         prev: &Self,

--- a/xilem_core/src/view.rs
+++ b/xilem_core/src/view.rs
@@ -53,7 +53,7 @@ pub trait View<State, Action, Context: ViewPathTracker>: 'static {
     ///
     /// This returns `element`, to allow parent views to modify the element after this `rebuild` has
     /// completed. This returning is needed as some reference types do not allow reborrowing,
-    /// without unweildly boilerplate.
+    /// without unwieldy boilerplate.
     fn rebuild<'el>(
         &self,
         prev: &Self,

--- a/xilem_core/tests/common/mod.rs
+++ b/xilem_core/tests/common/mod.rs
@@ -100,8 +100,8 @@ where
         prev: &Self,
         view_state: &mut Self::ViewState,
         ctx: &mut TestCx,
-        element: Mut<'el, TestElement>,
-    ) -> Mut<'el, TestElement> {
+        element: Mut<'el, Self::Element>,
+    ) -> Mut<'el, Self::Element> {
         let mut elements = SeqTracker {
             inner: element.children.as_mut().unwrap(),
             ix: 0,
@@ -116,7 +116,7 @@ where
         &self,
         view_state: &mut Self::ViewState,
         ctx: &mut TestCx,
-        element: Mut<'_, TestElement>,
+        element: Mut<'_, Self::Element>,
     ) {
         let mut elements = SeqTracker {
             inner: element.children.as_mut().unwrap(),
@@ -159,8 +159,8 @@ impl<const N: u32> View<(), Action, TestCx> for OperationView<N> {
         prev: &Self,
         _: &mut Self::ViewState,
         ctx: &mut TestCx,
-        element: Mut<'el, TestElement>,
-    ) -> Mut<'el, TestElement> {
+        element: Mut<'el, Self::Element>,
+    ) -> Mut<'el, Self::Element> {
         assert_eq!(&*element.view_path, ctx.view_path());
         element.operations.push(Operation::Rebuild {
             from: prev.0,
@@ -169,7 +169,7 @@ impl<const N: u32> View<(), Action, TestCx> for OperationView<N> {
         element
     }
 
-    fn teardown(&self, _: &mut Self::ViewState, ctx: &mut TestCx, element: Mut<'_, TestElement>) {
+    fn teardown(&self, _: &mut Self::ViewState, ctx: &mut TestCx, element: Mut<'_, Self::Element>) {
         assert_eq!(&*element.view_path, ctx.view_path());
         element.operations.push(Operation::Teardown(self.0));
     }

--- a/xilem_core/tests/common/mod.rs
+++ b/xilem_core/tests/common/mod.rs
@@ -95,13 +95,13 @@ where
         )
     }
 
-    fn rebuild(
+    fn rebuild<'el>(
         &self,
         prev: &Self,
         view_state: &mut Self::ViewState,
         ctx: &mut TestCx,
-        element: <Self::Element as ViewElement>::Mut<'_>,
-    ) {
+        element: Mut<'el, TestElement>,
+    ) -> Mut<'el, TestElement> {
         let mut elements = SeqTracker {
             inner: element.children.as_mut().unwrap(),
             ix: 0,
@@ -109,13 +109,14 @@ where
         };
         self.seq
             .seq_rebuild(&prev.seq, &mut view_state.0, ctx, &mut elements);
+        element
     }
 
     fn teardown(
         &self,
         view_state: &mut Self::ViewState,
         ctx: &mut TestCx,
-        element: <Self::Element as ViewElement>::Mut<'_>,
+        element: Mut<'_, TestElement>,
     ) {
         let mut elements = SeqTracker {
             inner: element.children.as_mut().unwrap(),
@@ -153,26 +154,22 @@ impl<const N: u32> View<(), Action, TestCx> for OperationView<N> {
         )
     }
 
-    fn rebuild(
+    fn rebuild<'el>(
         &self,
         prev: &Self,
         _: &mut Self::ViewState,
         ctx: &mut TestCx,
-        element: <Self::Element as ViewElement>::Mut<'_>,
-    ) {
+        element: Mut<'el, TestElement>,
+    ) -> Mut<'el, TestElement> {
         assert_eq!(&*element.view_path, ctx.view_path());
         element.operations.push(Operation::Rebuild {
             from: prev.0,
             to: self.0,
         });
+        element
     }
 
-    fn teardown(
-        &self,
-        _: &mut Self::ViewState,
-        ctx: &mut TestCx,
-        element: <Self::Element as ViewElement>::Mut<'_>,
-    ) {
+    fn teardown(&self, _: &mut Self::ViewState, ctx: &mut TestCx, element: Mut<'_, TestElement>) {
         assert_eq!(&*element.view_path, ctx.view_path());
         element.operations.push(Operation::Teardown(self.0));
     }
@@ -199,7 +196,7 @@ impl SuperElement<TestElement> for TestElement {
 
     fn with_downcast_val<R>(
         this: Self::Mut<'_>,
-        f: impl FnOnce(<TestElement as ViewElement>::Mut<'_>) -> R,
+        f: impl FnOnce(Mut<'_, TestElement>) -> R,
     ) -> (Self::Mut<'_>, R) {
         let ret = f(this);
         (this, ret)
@@ -257,7 +254,7 @@ impl<'a> ElementSplice<TestElement> for SeqTracker<'a> {
     fn insert(&mut self, element: TestElement) {
         self.inner.active.push(element);
     }
-    fn mutate<R>(&mut self, f: impl FnOnce(<TestElement as ViewElement>::Mut<'_>) -> R) -> R {
+    fn mutate<R>(&mut self, f: impl FnOnce(Mut<'_, TestElement>) -> R) -> R {
         let ix = self.ix;
         self.ix += 1;
         f(&mut self.inner.active[ix])
@@ -265,7 +262,7 @@ impl<'a> ElementSplice<TestElement> for SeqTracker<'a> {
     fn skip(&mut self, n: usize) {
         self.ix += n;
     }
-    fn delete<R>(&mut self, f: impl FnOnce(<TestElement as ViewElement>::Mut<'_>) -> R) -> R {
+    fn delete<R>(&mut self, f: impl FnOnce(Mut<'_, TestElement>) -> R) -> R {
         let ret = f(&mut self.inner.active[self.ix]);
         let val = self.inner.active.remove(self.ix);
         self.inner.deleted.push((self.ix, val));


### PR DESCRIPTION
So this resulted out of experimenting with a rewrite of `xilem_web` where I needed access to the element *after* wrapping views have used `View::rebuild`.
It was not possible to access the element anymore because of the move of element type `ViewElement::Mut`, so this (unfortunately further complexification) made this possible again by returning `ViewElement::Mut`. I've tested all the examples, and they all are running as expected.

Maybe this also helps with the reborrowing issue?